### PR TITLE
Fix shellcheck warnings in shell scripts

### DIFF
--- a/build-and-start.sh
+++ b/build-and-start.sh
@@ -1,5 +1,7 @@
+#!/bin/sh
+
 dir=$(pwd)
-cd $dir/mockit-routes && docker build -t mockit-routes .
-cd $dir/client && docker build -t mockit-client .
-cd $dir/server && docker build -t mockit-server .
+cd "$dir/mockit-routes" && docker build -t mockit-routes .
+cd "$dir/client" && docker build -t mockit-client .
+cd "$dir/server" && docker build -t mockit-server .
 docker-compose up -d

--- a/install-and-test.sh
+++ b/install-and-test.sh
@@ -1,5 +1,6 @@
+#!/bin/sh
+
 dir=$(pwd)
-CI=true
-cd $dir/mockit-routes && npm install && npm test .
-cd $dir/client && npm install && CI=true npm test -- --coverage
-cd $dir/server && npm install && npm test
+cd "$dir/mockit-routes" && npm install && npm test .
+cd "$dir/client" && npm install && CI=true npm test -- --coverage
+cd "$dir/server" && npm install && npm test


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: This fixes warnings reported by [ShellCheck](https://www.shellcheck.net/) (such as expanding unquoted variables).

<!-- Why are these changes necessary? -->

**Why**: Scripts should now work if the PWD contains spaces.

<!-- How were these changes implemented? -->

**How**: Editing the shell scripts.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Tests N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->