### PR TITLE
Move `nodemon` to `devDependencies`

### DIFF
--- a/mockit-routes/package.json
+++ b/mockit-routes/package.json
@@ -16,11 +16,11 @@
     "chokidar": "^2.0.4",
     "cors": "^2.8.5",
     "express": "^4.16.4",
-    "fs-extra": "^7.0.1",
-    "nodemon": "^1.18.9"
+    "fs-extra": "^7.0.1"
   },
   "devDependencies": {
     "jest": "^23.6.0",
+    "nodemon": "^1.18.11",
     "supertest": "^3.4.2"
   }
 }


### PR DESCRIPTION
By the way, I update `nodemon` to lastest version.


- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
