### PR TITLE
redundant build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ git clone git@github.com:boyney123/mockit.git
 ```
 
 ```sh
-cd mockit && sh build-and-start.sh
+cd mockit && docker-compose up
 ```
 
 Once everything is up and running go to [http://localhost:5000](http://localhost:5000) to see MockIt.

--- a/build-and-start.sh
+++ b/build-and-start.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-dir=$(pwd)
-cd "$dir/mockit-routes" && docker build -t mockit-routes .
-cd "$dir/client" && docker build -t mockit-client .
-cd "$dir/server" && docker build -t mockit-server .
-docker-compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,18 +2,21 @@ version: "3"
 services:
   mockit-routes:
     image: "mockit-routes"
+    build: "mockit-routes"
     ports:
       - 3000:3000
     volumes:
       - ./configuration/routes.json:/usr/src/mockit-routes/configuration/routes.json
   mockit-server:
     image: "mockit-server"
+    build: "server"
     ports:
       - 4000:4000
     volumes:
       - ./configuration/routes.json:/usr/src/mockit-server/configuration/routes.json
   mockit-client:
     image: "mockit-client"
+    build: "client"
     ports:
       - 5000:3000
     environment:


### PR DESCRIPTION
Hey, this is mostly FYI... feel free to decline it if you prefer your current setup.

The build feature is already part of docker-compose, so an extra script just to do it isn't really necessary.

strictly speaking, the `docker-compose up --build` is the exact copy of your previous build-and-start script. i left that flag out for brevity 