### PR TITLE
Set 'Mockit' as default page title

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -22,7 +22,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Mockit</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Sets 'Mockit' as default page title:
<img width="799" alt="Screen Shot 2019-04-26 at 9 09 37 AM" src="https://user-images.githubusercontent.com/148698/56810054-5f071100-6803-11e9-92aa-65cc8a994090.png">
**Why**:

The current page title is the default 'React App'
<img width="802" alt="Screen Shot 2019-04-26 at 9 05 42 AM" src="https://user-images.githubusercontent.com/148698/56810113-7e9e3980-6803-11e9-80a0-3f6bcbe05e13.png">

**How**:

Change the title tag in  client/public/index.html

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
