### PR TITLE
Removed build-deps in the client docker file

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11.4.0-alpine as build-deps
+FROM node:11.4.0-alpine
 RUN mkdir -p /usr/src/mockit-client
 WORKDIR /usr/src/mockit-client
 


### PR DESCRIPTION
This is from #18 .

No reason why the `build-deps` line was in there, cleaning up and removing.