### PR TITLE
Feature: Support Path By Query Param

### DIFF
--- a/mockit-routes/src/spec.js
+++ b/mockit-routes/src/spec.js
@@ -123,7 +123,17 @@ const exampleConfig = {
         }
       ],
       disabled: false
-    }
+    },
+    {
+      route: '/testParameter?id=1',
+      httpMethod: 'GET',
+      statusCode: '200',
+      delay: '0',
+      payload: {
+        test: true
+      },
+      disabled: false
+    },
   ]
 };
 
@@ -152,6 +162,13 @@ describe('Mockit Routes', () => {
       });
       it('when a route is configured with `DELETE` set as the httpMethod then that route can only be accessed through DELETE', async () => {
         await request(app).del('/deleteExample').expect(200, { test: true });
+      });
+      it('when a route is contain query parameter case match', async () => {
+        await request(app).get('/testParameter?id=1').expect(200, { test: true });
+      });
+      it('when a route is contain query parameter case not match', async () => {
+        await request(app).get('/testParameter?ids=1').expect(404, {});
+        await request(app).get('/testParameter?id=1&test=1').expect(404, {});
       });
     });
 


### PR DESCRIPTION
Example: localhost:3000/test?id=1
/test?id=1 [OK]
/test?id=2 [Not Found]

If need dynamic add new route
localhost:3000/test

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

<!-- Why are these changes necessary? -->

**Why**:

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
