### PR TITLE
feat(mockit-api) Enable request forwarding for unresolved HTTP requests

### DIFF
--- a/client/src/components/SettingsModal/index.js
+++ b/client/src/components/SettingsModal/index.js
@@ -143,9 +143,9 @@ const SettingsModal = function ({
             <div className="field" aria-label="feature-request-proxying">
               <label className="label">Request proxying</label>
               <p className="mb10">
-                Send unhandled requests to a real domain. Can be used to stub out
-                the functionality of a real endpoint, or to enrich a live API
-                with new mock endpoints.
+                Send unhandled requests to a real domain. Can be used to stub
+                out the functionality of a real endpoint, or to enrich a live
+                API with new mock endpoints.
               </p>
               <div className="control">
                 <input
@@ -164,6 +164,7 @@ const SettingsModal = function ({
                 </label>
 
                 <input
+                  aria-label="feature-request-proxying-text-input"
                   disabled={!proxying.enabled}
                   type="text"
                   className="mt10"

--- a/client/src/components/SettingsModal/index.js
+++ b/client/src/components/SettingsModal/index.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import _ from 'lodash';
 import { settings as applicationSettings } from '../../config/routes.json';
 import { updateSettings } from '../../utils/routes-api';
 
@@ -11,7 +12,13 @@ const SettingsModal = function ({
   const [settings, setSettings] = useState(applicationSettings);
 
   const {
-    features: { chaosMonkey, cors, authentication, groupedRoutes } = {}
+    features: {
+      chaosMonkey,
+      cors,
+      authentication,
+      groupedRoutes,
+      proxying = {}
+    } = {}
   } = settings;
 
   const setFeature = (feature, value) => {
@@ -19,7 +26,7 @@ const SettingsModal = function ({
       ...settings
     };
 
-    newSettings['features'][feature] = value;
+    _.set(newSettings, `features.${feature}`, value);
 
     setSettings(newSettings);
   };
@@ -92,8 +99,8 @@ const SettingsModal = function ({
             <div className="field" aria-label="feature-chaos-monkey">
               <label className="label">Chaos Monkey</label>
               <p className="mb10">
-                Unleash the monkey. The monkey will randomly take down end
-                points and enforce failures on your routes.
+                Unleash the monkey. The monkey will randomly take down endpoints
+                and enforce failures on your routes.
               </p>
               <div className="control">
                 <input
@@ -130,6 +137,42 @@ const SettingsModal = function ({
                 <label htmlFor="groupedRoutesFeature">
                   Enable Grouped Routes
                 </label>
+              </div>
+            </div>
+            <hr />
+            <div className="field" aria-label="feature-request-proxying">
+              <label className="label">Request proxying</label>
+              <p className="mb10">
+                Send unhandled requests to a real domain. Can be used to stub out
+                the functionality of a real endpoint, or to enrich a live API
+                with new mock endpoints.
+              </p>
+              <div className="control">
+                <input
+                  id="requestProxyingFeature"
+                  type="checkbox"
+                  name="requestProxyingFeature"
+                  className="switch is-primary"
+                  checked={proxying.enabled}
+                  onChange={(e) =>
+                    setFeature('proxying.enabled', e.target.checked)
+                  }
+                  aria-label="feature-request-proxying-input"
+                />
+                <label htmlFor="requestProxyingFeature">
+                  Enable Request Proxying
+                </label>
+
+                <input
+                  disabled={!proxying.enabled}
+                  type="text"
+                  className="mt10"
+                  placeholder="https://your-api.example.com"
+                  value={proxying.domain}
+                  onChange={(e) =>
+                    setFeature('proxying.domain', e.target.value)
+                  }
+                />
               </div>
             </div>
           </section>

--- a/client/src/components/SettingsModal/spec.js
+++ b/client/src/components/SettingsModal/spec.js
@@ -100,6 +100,42 @@ describe('Settings Dialog', () => {
         );
       });
     });
+    describe('Request Proxying', () => {
+      it('renders the feature with an input', () => {
+        const { getByLabelText } = render(<SettingsDialog />);
+        expect(getByLabelText('feature-request-proxying')).toBeVisible();
+        expect(getByLabelText('feature-request-proxying-input')).toBeVisible();
+        expect(
+          getByLabelText('feature-request-proxying-text-input')
+        ).toBeVisible();
+      });
+
+      it('clicking on the feature enables request proxying and updates the input value', () => {
+        const { getByLabelText } = render(<SettingsDialog />);
+
+        expect(
+          getByLabelText('feature-request-proxying-input').checked
+        ).toEqual(false);
+        fireEvent.change(getByLabelText('feature-request-proxying-input'), {
+          target: { checked: true }
+        });
+        expect(
+          getByLabelText('feature-request-proxying-input').checked
+        ).toEqual(true);
+      });
+
+      it('disables the input field when the feature is disabled', () => {
+        const { getByLabelText } = render(<SettingsDialog />);
+
+        expect(
+          getByLabelText('feature-request-proxying-text-input').disabled
+        ).toEqual(true);
+        fireEvent.click(getByLabelText('feature-request-proxying-input'));
+        expect(
+          getByLabelText('feature-request-proxying-text-input').disabled
+        ).toEqual(false);
+      });
+    });
   });
 
   describe('saving settings', () => {

--- a/client/src/scss/App.scss
+++ b/client/src/scss/App.scss
@@ -74,6 +74,15 @@ main {
   flex-direction: column;
 }
 
+input[type='text'] {
+  font-size: 16px;
+  display: block;
+  border-radius: 4px;
+  border: 2px #c4c4c4 solid;
+  padding: 5px;
+  width: 100%;
+}
+
 /* Route */
 
 .no-routes {

--- a/configuration/routes.json
+++ b/configuration/routes.json
@@ -4,7 +4,11 @@
       "chaosMonkey": false,
       "cors": true,
       "authentication": false,
-      "groupedRoutes": false
+      "groupedRoutes": false,
+      "proxying": {
+        "enabled": false,
+        "domain": ""
+      }
     },
     "authentication": {
       "username": "test",

--- a/mockit-routes/package-lock.json
+++ b/mockit-routes/package-lock.json
@@ -1456,6 +1456,11 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://artifactory.tsp.cld.touchtunes.com/api/npm/web-dev/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha1-TrIVlMlyvEBVPSduUQU5FD21Pgo="
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -1624,6 +1629,31 @@
         "type-is": "~1.6.16",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
+      }
+    },
+    "express-http-proxy": {
+      "version": "1.6.2",
+      "resolved": "https://artifactory.tsp.cld.touchtunes.com/api/npm/web-dev/express-http-proxy/-/express-http-proxy-1.6.2.tgz",
+      "integrity": "sha1-6HFS5FlYzuS5HaL9qiCh/9WBIEo=",
+      "requires": {
+        "debug": "^3.0.1",
+        "es6-promise": "^4.1.1",
+        "raw-body": "^2.3.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://artifactory.tsp.cld.touchtunes.com/api/npm/web-dev/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha1-clgLfpFF+zm2Z2+cXl+xALk0F5o=",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://artifactory.tsp.cld.touchtunes.com/api/npm/web-dev/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI="
+        }
       }
     },
     "extend": {

--- a/mockit-routes/package-lock.json
+++ b/mockit-routes/package-lock.json
@@ -1458,8 +1458,8 @@
     },
     "es6-promise": {
       "version": "4.2.8",
-      "resolved": "https://artifactory.tsp.cld.touchtunes.com/api/npm/web-dev/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha1-TrIVlMlyvEBVPSduUQU5FD21Pgo="
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -1633,8 +1633,8 @@
     },
     "express-http-proxy": {
       "version": "1.6.2",
-      "resolved": "https://artifactory.tsp.cld.touchtunes.com/api/npm/web-dev/express-http-proxy/-/express-http-proxy-1.6.2.tgz",
-      "integrity": "sha1-6HFS5FlYzuS5HaL9qiCh/9WBIEo=",
+      "resolved": "https://registry.npmjs.org/express-http-proxy/-/express-http-proxy-1.6.2.tgz",
+      "integrity": "sha512-soP7UXySFdLbeeMYL1foBkEoZj6HELq9BDAOCr1sLRpqjPaFruN5o6+bZeC+7U4USWIl4JMKEiIvTeKJ2WQdlQ==",
       "requires": {
         "debug": "^3.0.1",
         "es6-promise": "^4.1.1",
@@ -1643,16 +1643,16 @@
       "dependencies": {
         "debug": {
           "version": "3.2.7",
-          "resolved": "https://artifactory.tsp.cld.touchtunes.com/api/npm/web-dev/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha1-clgLfpFF+zm2Z2+cXl+xALk0F5o=",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "ms": {
           "version": "2.1.3",
-          "resolved": "https://artifactory.tsp.cld.touchtunes.com/api/npm/web-dev/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI="
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },

--- a/mockit-routes/package.json
+++ b/mockit-routes/package.json
@@ -16,6 +16,7 @@
     "chokidar": "^2.1.5",
     "cors": "^2.8.5",
     "express": "^4.16.4",
+    "express-http-proxy": "^1.6.2",
     "fs-extra": "^7.0.1",
     "nodemon": "^1.18.11"
   },

--- a/mockit-routes/src/index.js
+++ b/mockit-routes/src/index.js
@@ -15,12 +15,13 @@ const data = fs.readJsonSync(
   path.resolve(__dirname, '../configuration/routes.json')
 );
 const { routes, settings: { features = {} } = {} } = data;
+const { proxying = {}, cors: corsFeature } = features;
 
 app.use(basicAuth);
 app.use(delayMiddleware);
 app.use(chaosMonkeyMiddleware);
 
-if (features.cors) {
+if (corsFeature) {
   app.use(cors());
 }
 
@@ -48,8 +49,8 @@ routes.forEach((route) => {
   }
 });
 
-if (features.proxying.enabled && features.proxying.domain) {
-  app.use(proxy(features.proxying.domain));
+if (proxying.enabled && proxying.domain) {
+  app.use(proxy(proxying.domain));
 }
 
 if (process.env.ENV !== 'test') {


### PR DESCRIPTION
**What**:

This PR allows unmatched requests against the MockIt API server (i.e. requests without a matching user-defined path) to be proxied to a real domain. This is particularly useful when working with an existing API: you can "override" a real endpoint with a mock, or enrich the API with all-new mock endpoints. The feature is configurable via the settings panel:

![image](https://user-images.githubusercontent.com/20796409/104745712-62030d00-571c-11eb-86f9-2a64461e9cb1.png)

**Why**:

See above. I actually implemented the feature to support a project I'm working on. Several API mocking tools (like the ever-popular [Mockoon](https://github.com/mockoon/mockoon)) support the feature, so I thought this would be a welcome addition here.

<!-- How were these changes implemented? -->

**How**:

The proxy confiugration is set via the Settings Modal and stored in the `routes.json` file. When the `settings.proxying.enabled` flag is `true`, requests are proxied over to the designated domain via `express-http-proxy`. Given that `settings.proxying` is an object, I also updated `setFeature` in the `settingsModal` to support deeply nested object paths.

Client-side tests are implemented, but I'm still working on server-side tests. Reviews would be appreciated in the meantime.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Tests **Client-side tests implemented, server-side tests in-progress**
- [ ] Ready to be merged
