### PR TITLE
delay middleware supports dynamic routes

### DIFF
--- a/mockit-routes/src/middlewares/delay/index.js
+++ b/mockit-routes/src/middlewares/delay/index.js
@@ -5,14 +5,46 @@ const data = fs.readJsonSync(
 );
 const { routes } = data;
 
-const findRoute = (path) => {
-  return routes.find(({ route } = {}) => {
+const checkRouteParamsPath = (path, relativePath) => {
+  const pathArray = path.split('/');
+  const relPathArray = relativePath.split('/');
+  if (pathArray.length === relPathArray.length) {
+    pathArray.forEach((param, i) => {
+      if (param.startsWith(':')) {
+        delete pathArray[i];
+        delete relPathArray[i];
+      }
+    });
+
+    return pathArray.join('') === relPathArray.join('');
+  }
+
+  return false;
+};
+
+const findRoute = (path, method) => {
+
+  const match = routes.find(({ route } = {}) => {
     return route === path;
+  });
+
+  if (match) {
+    return match;
+  }
+
+  // route has params
+  return routes.find(({ route, httpMethod } = {}) => {
+    // check method
+    if (httpMethod && method.toLowerCase() === httpMethod.toLowerCase()) {
+      return checkRouteParamsPath(route, path);
+    }
+
+    return false;
   });
 };
 
 module.exports = (req, res, next) => {
-  const { delay = 0 } = findRoute(req.url) || {};
+  const { delay = 0 } = findRoute(req.url, req.method) || {};
 
   if (delay > 0) {
     return setTimeout(next, delay);

--- a/mockit-routes/src/spec.js
+++ b/mockit-routes/src/spec.js
@@ -102,6 +102,16 @@ const exampleConfig = {
       disabled: false
     },
     {
+      route: '/delayDynamicExample/:id',
+      httpMethod: 'GET',
+      statusCode: '200',
+      delay: '2000',
+      payload: {
+        test: true
+      },
+      disabled: false
+    },
+    {
       route: '/500Example',
       httpMethod: 'GET',
       statusCode: '500',
@@ -172,6 +182,12 @@ describe('Mockit Routes', () => {
     describe('delayed routes', () => {
       it('when a route has a delay configured on it, the response will come back after the delay has fulfilled', async () => {
         await request(app).get('/delayExample').expect(200, { test: true });
+      });
+    });
+
+    describe('delayed dynamic routes', () => {
+      it('when a dynamic route has a delay configured on it, the response will come back after the delay has fulfilled', async () => {
+        await request(app).get('/delayDynamicExample/101').expect(200, { test: true });
       });
     });
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Enhance delay middleware to support dynamic routes (ie.  /my-route/:id)

<!-- Why are these changes necessary? -->

Adding a delay to dynamic routes does not work as expected

<!-- How were these changes implemented? -->

delay/index.js middleware has been modified to include a checkRouteParamsPath method that checks if a dynamic route in routes.json matches the current request.  The expectation is that if there is a match and a delay value is set on the route, then the route will respect the delay before returning the response.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
